### PR TITLE
Do not swallow zero values.

### DIFF
--- a/src/XML2Array.php
+++ b/src/XML2Array.php
@@ -118,8 +118,8 @@ class XML2Array
                         }
                         $output[$t][] = $v;
                     } else {
-                        //check if it is not an empty node
-                        if (!empty($v)) {
+                        // check if it is not an empty node or '0'
+                        if (!empty($v) || '0' === $v) {
                             $output = $v;
                         }
                     }

--- a/tests/scripts/generate_tests.php
+++ b/tests/scripts/generate_tests.php
@@ -32,6 +32,7 @@ function generateTags($tags)
     $cDataSet = [
         'Null value' => 'null',
         'Empty value' => '',
+        'Zero value' => '0',
         'Simple value' => 'normal',
         'Encoded value' => '&lt;escaped&gt;',
         'Empty CDATA' => '<![CDATA[]]>',


### PR DESCRIPTION
In case a tag contains '0' as value the data was turned into empty
value. So '<foo>0<foo>' converted to array and back to xml was turned
into '<foo></foo>'.

I'm not sure about the tests, because they would also work without the fix, because it selftesting in this case.